### PR TITLE
PayPal donation handling

### DIFF
--- a/app/Events/UnknownPayPalPaymentReceived.php
+++ b/app/Events/UnknownPayPalPaymentReceived.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BB\Events;
+
+use BB\Events\Event;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class UnknownPayPalPaymentReceived extends Event
+{
+    use SerializesModels;
+
+    /**
+     * @var int
+     */
+    public $paymentId;
+    /**
+     * @var string
+     */
+    public $emailAddress;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param int $paymentId
+     * @param     $emailAddress
+     */
+    public function __construct($paymentId, $emailAddress)
+    {
+        $this->paymentId = $paymentId;
+        $this->emailAddress = $emailAddress;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Http/Controllers/PaypalIPNController.php
+++ b/app/Http/Controllers/PaypalIPNController.php
@@ -45,7 +45,9 @@ class PaypalIPNController extends Controller
                 $user = User::where('secondary_email', $ipnData['payer_email'])->first();
             }
             if ( ! $user) {
-                \Log::error("PayPal IPN Received for unknown email " . $ipnData['payer_email']);
+                //\Log::error("PayPal IPN Received for unknown email " . $ipnData['payer_email']);
+                $paymentId = $this->paymentRepository->recordPayment('donation', 0, 'paypal', $ipnData['txn_id'], $ipnData['mc_gross'], 'paid', $ipnData['mc_fee'], $ipnData['payer_email']);
+                event(new \BB\Events\UnknownPayPalPaymentReceived($paymentId, $ipnData['payer_email']));
                 return;
             }
 

--- a/app/Listeners/EmailDonorAboutUnknownPayPalPayment.php
+++ b/app/Listeners/EmailDonorAboutUnknownPayPalPayment.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BB\Listeners;
+
+use BB\Repo\PaymentRepository;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Mail\Mailer;
+use BB\Events\UnknownPayPalPaymentReceived;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class EmailDonorAboutUnknownPayPalPayment implements ShouldQueue
+{
+    /**
+     * @var Mailer
+     */
+    private $mailer;
+    /**
+     * @var PaymentRepository
+     */
+    private $paymentRepository;
+
+    /**
+     * Create the event listener.
+     *
+     * @param Mailer            $mailer
+     * @param PaymentRepository $paymentRepository
+     */
+    public function __construct(Mailer $mailer, PaymentRepository $paymentRepository)
+    {
+        $this->mailer            = $mailer;
+        $this->paymentRepository = $paymentRepository;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param UnknownPayPalPaymentReceived $event
+     */
+    public function handle(UnknownPayPalPaymentReceived $event)
+    {
+        $email = $event->emailAddress;
+        $payment = $this->paymentRepository->getById($event->paymentId);
+        $this->mailer->send('emails.paypal-donation', ['email' => $email, 'payment' => $payment], function ($m) use ($email) {
+            $m->to($email);
+            $m->cc('trustees@buildbrighton.com');
+            $m->subject('Unknown PayPal Payment Received');
+        });
+    }
+}

--- a/app/Presenters/PaymentPresenter.php
+++ b/app/Presenters/PaymentPresenter.php
@@ -28,6 +28,8 @@ class PaymentPresenter extends Presenter
                 return 'Consumables (' . $this->entity->reference . ')';
             case 'transfer':
                 return 'Transfer (to ' . $this->entity->reference . ')';
+            case 'donation':
+                return 'Donation';
             default:
                 return $this->entity->reason;
         }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace BB\Providers;
 
 use BB\Listeners\AddApprovedExpenseToBalance;
+use BB\Listeners\EmailDonorAboutUnknownPayPalPayment;
 use BB\Listeners\EmailMemberAboutApprovedExpense;
 use BB\Listeners\EmailMemberAboutDeclinedExpense;
 use BB\Listeners\EmailMemberAboutDeclinedPhoto;
@@ -64,7 +65,10 @@ class EventServiceProvider extends ServiceProvider {
         ],
         'BB\Events\NewMemberNotification' => [
             SlackMemberNotification::class
-        ]
+        ],
+        '\BB\Events\UnknownPayPalPaymentReceived' => [
+            EmailDonorAboutUnknownPayPalPayment::class
+        ],
 	];
 
 	/**

--- a/resources/views/emails/paypal-donation.blade.php
+++ b/resources/views/emails/paypal-donation.blade.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<p>
+    Hi,<br />
+    We have received a PayPal payment for &pound;{{ $payment->amount }} from your account {{ $email }},
+    this is an unrecognised address so we have recorded it as a donation.<br />
+    <br />
+    If this was intentional, thank you for your support and contributions to keeping Build Brighton running.<br />
+    <br />
+    If this wasn't was you were expecting its most likely because you didn't enter your primary PayPal email address in to your account.
+    Please update your account with the email address above and contact the trustees at
+    <a href="mailto:trustees@buildbrighton.com">trustees@buildbrighton.com</a> quoting the payment id {{ $payment->id }}.
+
+    Thank you,
+    The Build Brighton Trustees
+</p>
+</body>
+</html>


### PR DESCRIPTION
When an unknown paypal payment is received record it as a donation and email the user who sent it