### PR TITLE
Show the members balance on their account page - Fixes #165

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -65,7 +65,8 @@ class AccountController extends Controller
         \BB\Repo\UserRepository $userRepository,
         \BB\Validators\ProfileValidator $profileValidator,
         \BB\Repo\AddressRepository $addressRepository,
-        \BB\Repo\SubscriptionChargeRepository $subscriptionChargeRepository)
+        \BB\Repo\SubscriptionChargeRepository $subscriptionChargeRepository,
+        \BB\Services\Credit $bbCredit)
     {
         $this->userForm = $userForm;
         $this->updateSubscriptionAdminForm = $updateSubscriptionAdminForm;
@@ -79,6 +80,7 @@ class AccountController extends Controller
         $this->profileValidator = $profileValidator;
         $this->addressRepository = $addressRepository;
         $this->subscriptionChargeRepository = $subscriptionChargeRepository;
+        $this->bbCredit = $bbCredit;
 
         //This tones down some validation rules for admins
         $this->userForm->setAdminOverride( ! \Auth::guest() && \Auth::user()->hasRole('admin'));
@@ -187,7 +189,16 @@ class AccountController extends Controller
         //Get the member subscription payments
         $subscriptionCharges = $this->subscriptionChargeRepository->getMemberChargesPaginated($id);
 
-        return \View::make('account.show')->with('user', $user)->with('inductions', $inductions)->with('newAddress', $newAddress)->with('subscriptionCharges', $subscriptionCharges);
+        //Get the members balance
+        $this->bbCredit->setUserId($user->id);
+        $memberBalance = $this->bbCredit->getBalanceFormatted();
+
+        return \View::make('account.show')
+            ->with('user', $user)
+            ->with('inductions', $inductions)
+            ->with('newAddress', $newAddress)
+            ->with('subscriptionCharges', $subscriptionCharges)
+            ->with('memberBalance', $memberBalance);
     }
 
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -7164,6 +7164,7 @@ body.register_login #pageTitle {
 @media screen and (min-width: 768px) {
   .memberSubAmount p {
     float: right !important;
+	text-align: right;
   }
   .memberSubAmount form {
     float: right !important;

--- a/resources/views/account/partials/member-status-bar.blade.php
+++ b/resources/views/account/partials/member-status-bar.blade.php
@@ -56,6 +56,7 @@
     <div class="col-xs-12 col-sm-4">
         <div class="memberSubAmount">
             <p class="navbar-text">
+                Balance: {{ $memberBalance }} <br />
                 {{ $user->present()->subscriptionDetailLine }}
                 @if ($user->canMemberChangeSubAmount())
                     <small><a href="#" class="js-show-alter-subscription-amount" title="Change Amount">Change</a></small>


### PR DESCRIPTION
I went with the assumption that you wanted this in plain text instead of the same balance panel on the Balance page so not to clutter the page. Let me know if you wanted something a bit more styled. 

Looks fine on mobile, and with all items in the status bar enabled too. 

![screen shot 2016-01-01 at 19 00 13](https://cloud.githubusercontent.com/assets/109852/12071890/12650d72-b0bc-11e5-8da8-2a5d7f62ae8d.png)

![screen shot 2016-01-01 at 19 00 29](https://cloud.githubusercontent.com/assets/109852/12071891/1265ca6e-b0bc-11e5-8e0e-1dc862f3c24d.png)