### PR TITLE
ACS: Add check for user validity for device nodes

### DIFF
--- a/app/Http/Controllers/ACS/ActivityController.php
+++ b/app/Http/Controllers/ACS/ActivityController.php
@@ -66,6 +66,7 @@ class ActivityController extends Controller
             $this->fobAccess->verifyForEntry($activityRequest->getTagId(), $activityRequest->getDevice(), $activityRequest->getOccurredAt());
             $this->fobAccess->logSuccess();
         } else {
+            $this->fobAccess->verifyForDevice($activityRequest->getTagId(), $activityRequest->getDevice(), $activityRequest->getOccurredAt());
             $activityId = $this->equipmentLogRepository->recordStartCloseExisting($keyFob->user->id, $keyFob->id, $activityRequest->getDevice());
             event(new MemberActivity($keyFob, $activityRequest->getDevice()));
         }


### PR DESCRIPTION
This change is to add a check that the user is trained on a device before starting a new activity session. If not trained, I expect a VaildationException to be thrown which would result in a 422 response with a corresponding message body.