### PR TITLE
Disable Slack notifications

### DIFF
--- a/app/Listeners/SlackActivityNotification.php
+++ b/app/Listeners/SlackActivityNotification.php
@@ -25,7 +25,7 @@ class SlackActivityNotification
     public function handle(MemberActivity $event)
     {
         if (\App::environment('production')) {
-            \Slack::send($event->keyFob->user->name . ' is in the space');
+            // \Slack::send($event->keyFob->user->name . ' is in the space');
         }
     }
 }

--- a/app/Listeners/SlackMemberNotification.php
+++ b/app/Listeners/SlackMemberNotification.php
@@ -33,7 +33,7 @@ class SlackMemberNotification implements ShouldQueue
                 return;
             }
 
-            \Slack::to($event->notification->user()->slack_username)->send($event->notification->message);
+            // \Slack::to($event->notification->user()->slack_username)->send($event->notification->message);
 
             $event->notification->update(['notified_method' => 'slack', 'notified_at' => Carbon::now()]);
         }


### PR DESCRIPTION
The Slack API seems to have started returning 403's today, which in turn has caused the BBMS access control API to start incorrectly returning 500's. This pull requests simply disables Slack notifications in order to prevent exceptions getting raised internally.

We don't use Slack any more so hopefully disabling it shouldn't cause any problems.