### PR TITLE
Disable more Slack notifications

### DIFF
--- a/app/Http/Controllers/CCTVController.php
+++ b/app/Http/Controllers/CCTVController.php
@@ -20,7 +20,7 @@ class CCTVController extends Controller
             $newFilename = \App::environment() . '/cctv/' . $date->year . '/' . $date->month . '/' . $date->day . '/' . $fileName . '.jpg';
             Storage::put($newFilename, file_get_contents($file), 'public');
 
-            \Slack::to("#cctv")->attach(['image_url'=>'https://s3-eu-west-1.amazonaws.com/buildbrighton-bbms/' . $newFilename, 'color'=>'warning'])->send('New image');
+            // \Slack::to("#cctv")->attach(['image_url'=>'https://s3-eu-west-1.amazonaws.com/buildbrighton-bbms/' . $newFilename, 'color'=>'warning'])->send('New image');
         }
     }
 
@@ -128,7 +128,7 @@ class CCTVController extends Controller
 
             //Log::debug('Event Gif generated :https://s3-eu-west-1.amazonaws.com/buildbrighton-bbms/'.$newFilename);
 
-            \Slack::to("#cctv")->attach(['image_url'=>'https://s3-eu-west-1.amazonaws.com/buildbrighton-bbms/' . $newFilename, 'color'=>'warning'])->send('Movement detected');
+            // \Slack::to("#cctv")->attach(['image_url'=>'https://s3-eu-west-1.amazonaws.com/buildbrighton-bbms/' . $newFilename, 'color'=>'warning'])->send('Movement detected');
 
         }
     }

--- a/app/Observer/UserObserver.php
+++ b/app/Observer/UserObserver.php
@@ -76,8 +76,8 @@ class UserObserver
      */
     private function sendSlackNotification($channel, $message)
     {
-        if (\App::environment('production')) {
-            \Slack::to($channel)->send($message);
-        }
+        // if (\App::environment('production')) {
+        //     \Slack::to($channel)->send($message);
+        // }
     }
 } 


### PR DESCRIPTION
Hey Arthur, just another small change to disable the remaining failing Slack calls which appear to be negatively affecting setting up new members.

Ideally we would like to replace these with Discord webhooks, but fixing the errors is more urgent.
