### PR TITLE
Key access control: improve log messages

### DIFF
--- a/app/Services/DeviceSession.php
+++ b/app/Services/DeviceSession.php
@@ -84,7 +84,7 @@ class DeviceSession extends KeyFobAccess
         //Make sure the user is active
         $this->user = $this->keyFob->user()->first();
         if ( ! $this->user || ! $this->user->active) {
-            throw new ValidationException('User Invalid');
+            throw new ValidationException('User Invalid or not an active member');
         }
 
         //Make sure the user is allowed to use the device

--- a/app/Services/KeyFobAccess.php
+++ b/app/Services/KeyFobAccess.php
@@ -170,22 +170,22 @@ class KeyFobAccess
         $this->user = $this->keyFob->user;
         if ( ! $this->user || ! $this->user->active) {
             $this->logFailure();
-            throw new ValidationException('Not a member');
+            throw new ValidationException('Not an active member');
         }
 
         if ( ! $this->user->trusted) {
             $this->logFailure();
-            throw new ValidationException('Not a keyholder');
+            throw new ValidationException('Member is not marked trusted');
         }
 
         if ( ! $this->user->key_holder) {
             $this->logFailure();
-            throw new ValidationException('Not a keyholder');
+            throw new ValidationException('Member is not a key holder');
         }
 
         if ( ! ($this->user->profile->profile_photo || $this->user->profile->profile_photo_on_wall)) {
             $this->logFailure();
-            throw new ValidationException('Member not trusted');
+            throw new ValidationException('Member photo not uploaded and approved');
         }
 
         $this->memberName = $this->user->given_name;

--- a/app/Services/KeyFobAccess.php
+++ b/app/Services/KeyFobAccess.php
@@ -206,7 +206,7 @@ class KeyFobAccess
         $this->user = $this->keyFob->user;
         if ( ! $this->user || ! $this->user->active) {
             $this->logFailure();
-            throw new ValidationException('Not a member');
+            throw new ValidationException('Not an active member');
         }
 
         //Validate the device


### PR DESCRIPTION
Log messages currently don't accurately reflect what the problem is when a key fob doesn't work. This change is to improve the messaging a bit to make it clearer when something has been forgotten.